### PR TITLE
세션 6: 트랜잭션과 히스토리

### DIFF
--- a/packages/core/src/command/CompositeCommand.ts
+++ b/packages/core/src/command/CompositeCommand.ts
@@ -1,0 +1,46 @@
+import { State } from "../state";
+import { Command } from "./types";
+
+export class CompositeCommand
+  implements Command
+{
+  readonly type = "composite";
+  readonly label: string;
+  private readonly commands: Command[];
+
+  constructor(commands: Command[]) {
+    this.label = "composite";
+    this.commands = commands;
+  }
+
+  execute(state: State): State {
+    let next = state;
+
+    // sweep
+    for (const cmd of this.commands) {
+      next = cmd.execute(next);
+    }
+
+    return next;
+  }
+
+  undo(state: State): State {
+    let next = state;
+
+    // reverse sweep
+    for (
+      let i = this.commands.length - 1;
+      i >= 0;
+      i--
+    ) {
+      next =
+        this.commands[i].undo(next);
+    }
+
+    return next;
+  }
+
+  isEmpty(): boolean {
+    return this.commands.length === 0;
+  }
+}

--- a/packages/core/src/history/HistoryManager.ts
+++ b/packages/core/src/history/HistoryManager.ts
@@ -1,0 +1,131 @@
+import { CompositeCommand } from "../command/CompositeCommand";
+import { Command } from "../command/types";
+import { State } from "../state";
+
+type Entry = {
+  label: string;
+  command: Command;
+};
+
+type CollectCommand = (
+  command: Command,
+) => void;
+
+export class HistoryManager {
+  private _undo: Entry[] = [];
+  private _redo: Entry[] = [];
+  private _state: State;
+
+  constructor(initial: State) {
+    this._state = initial;
+  }
+
+  get state(): State {
+    return this._state;
+  }
+
+  get stacks() {
+    const mapEntryLabel = (
+      entries: Entry[],
+    ) =>
+      entries.map(
+        (entry) => entry.label,
+      );
+
+    return {
+      undo: mapEntryLabel(this._undo),
+      redo: mapEntryLabel(this._redo),
+    };
+  }
+
+  group<T>(
+    label: string,
+    collector: (
+      collectCommand: CollectCommand,
+    ) => T,
+  ): T {
+    const bucket: Array<Command> = [];
+    const snapshot = this._state;
+
+    let result: T;
+
+    try {
+      result = collector((c: Command) =>
+        bucket.push(c),
+      );
+
+      if (bucket.length === 0)
+        return result;
+
+      const composite =
+        new CompositeCommand(bucket);
+      const executed =
+        composite.execute(snapshot);
+
+      if (executed === snapshot)
+        return result; // no-op
+
+      this._undo.push({
+        label,
+        command: composite,
+      });
+      this._redo = [];
+      this._state = executed;
+
+      return result;
+    } catch (error) {
+      this._state = snapshot; // rollback
+
+      throw error;
+    }
+  }
+
+  execute(
+    label: string,
+    command: Command,
+  ): void {
+    const prev = this._state;
+    const next = command.execute(prev);
+
+    if (next === prev) {
+      // no-op이면 기록 생략
+      this._redo = [];
+      return;
+    }
+
+    this._undo.push({ label, command });
+    this._redo = [];
+    this._state = next;
+  }
+
+  undo(): void {
+    const entry = this._undo.pop();
+
+    if (!entry) return;
+
+    const next = entry.command.undo(
+      this._state,
+    );
+
+    this._redo.push(entry);
+    this._state = next;
+  }
+
+  redo() {
+    const entry = this._redo.pop();
+
+    if (!entry) return;
+
+    const next = entry.command.execute(
+      this._state,
+    );
+
+    this._undo.push(entry);
+    this._state = next;
+  }
+
+  clear() {
+    this._undo = [];
+    this._redo = [];
+  }
+}

--- a/packages/core/src/history/history.test.ts
+++ b/packages/core/src/history/history.test.ts
@@ -1,0 +1,280 @@
+import {
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { HistoryManager } from "./HistoryManager";
+import { SetTransformCommand } from "../command/commands/SetTransformCommand";
+import { Transform } from "../transform/types";
+import { EntityNotFoundError } from "../common/errors";
+
+function t(
+  x: number,
+  y: number,
+  z: number,
+): [number, number, number] {
+  return [x, y, z];
+}
+function transform(
+  p: [number, number, number],
+  r: [number, number, number],
+  s: [number, number, number],
+): Transform {
+  return {
+    position: p,
+    rotation: r,
+    scale: s,
+  };
+}
+
+function makeInitialState() {
+  return {
+    entities: {
+      a: { name: "A" },
+      b: { name: "B" },
+    },
+    components: {
+      transform: {
+        a: transform(
+          t(0, 0, 0),
+          t(0, 0, 0),
+          t(1, 1, 1),
+        ),
+        b: transform(
+          t(5, 0, 0),
+          t(0, 0, 0),
+          t(1, 1, 1),
+        ),
+      },
+    },
+  };
+}
+
+describe("HistoryManager", () => {
+  it("그룹 이동이 한 엔트리로 쌓이고 undo/redo가 왕복된다.", () => {
+    const history = new HistoryManager(
+      makeInitialState(),
+    );
+
+    history.group(
+      "그룹 이동",
+      (collectCommand) => {
+        const a =
+          history.state.components
+            .transform["a"].position;
+        const b =
+          history.state.components
+            .transform["b"].position;
+
+        collectCommand(
+          new SetTransformCommand("a", {
+            position: [
+              a[0] + 10,
+              a[1],
+              a[2],
+            ],
+          }),
+        );
+
+        collectCommand(
+          new SetTransformCommand("b", {
+            position: [
+              b[0] + 10,
+              b[1],
+              b[2],
+            ],
+          }),
+        );
+      },
+    );
+
+    // 각각 position x를 10씩 이동(=그룹이동)한 후의 결과
+    expect(history.stacks.undo).toEqual(
+      ["그룹 이동"],
+    );
+    const after = history.state;
+    expect(
+      after.components.transform["a"]
+        .position,
+    ).toEqual([10, 0, 0]);
+    expect(
+      after.components.transform["b"]
+        .position,
+    ).toEqual([15, 0, 0]);
+
+    // 10씩 이동한 것 철회
+    history.undo();
+    expect(history.stacks.redo).toEqual(
+      ["그룹 이동"],
+    );
+    expect(history.stacks.redo).toEqual(
+      ["그룹 이동"],
+    );
+    expect(
+      history.state.components
+        .transform["a"].position,
+    ).toEqual([0, 0, 0]);
+    expect(
+      history.state.components
+        .transform["b"].position,
+    ).toEqual([5, 0, 0]);
+
+    // 다시 적용
+    history.redo();
+    expect(
+      history.state.components
+        .transform["a"].position,
+    ).toEqual([10, 0, 0]);
+    expect(
+      history.state.components
+        .transform["b"].position,
+    ).toEqual([15, 0, 0]);
+  });
+
+  it("그룹 내 커맨드 실패(EntityNotFoundError) 시 전체 롤백되고 기록되지 않는다", () => {
+    const history = new HistoryManager(
+      makeInitialState(),
+    );
+    const before = history.state;
+
+    expect(() => {
+      history.group(
+        "실패 그룹",
+        (collect) => {
+          // 존재하는 a는 성공 커맨드
+          const a =
+            history.state.components
+              .transform["a"].position;
+          collect(
+            new SetTransformCommand(
+              "a",
+              {
+                position: [
+                  a[0] + 1,
+                  a[1],
+                  a[2],
+                ],
+              },
+            ),
+          );
+          // 존재하지 않는 id → setTransform 내부에서 EntityNotFoundError
+          collect(
+            new SetTransformCommand(
+              "ghost",
+              { position: [0, 0, 0] },
+            ),
+          );
+        },
+      );
+    }).toThrow(EntityNotFoundError);
+
+    // 롤백 확인: 상태 불변, 히스토리 미기록
+    expect(history.state).toEqual(
+      before,
+    );
+    expect(history.stacks.undo).toEqual(
+      [],
+    );
+    expect(history.stacks.redo).toEqual(
+      [],
+    );
+  });
+
+  it("단일 실행에서 위치와 스케일을 동시에 패치하고 undo로 복구된다", () => {
+    const history = new HistoryManager(
+      makeInitialState(),
+    );
+
+    history.execute(
+      "프리셋",
+      new SetTransformCommand("a", {
+        position: [1, 2, 3],
+        scale: [2, 2, 2],
+      }),
+    );
+
+    expect(history.stacks.undo).toEqual(
+      ["프리셋"],
+    );
+    expect(
+      history.state.components
+        .transform["a"].position,
+    ).toEqual([1, 2, 3]);
+    expect(
+      history.state.components
+        .transform["a"].scale,
+    ).toEqual([2, 2, 2]);
+
+    history.undo();
+    expect(
+      history.state.components
+        .transform["a"].position,
+    ).toEqual([0, 0, 0]);
+    expect(
+      history.state.components
+        .transform["a"].scale,
+    ).toEqual([1, 1, 1]);
+  });
+
+  it("undo 이후 새 execute가 발생하면 redo 스택이 초기화된다", () => {
+    const history = new HistoryManager(
+      makeInitialState(),
+    );
+
+    // 첫 변경
+    history.execute(
+      "이동1",
+      new SetTransformCommand("a", {
+        position: [10, 0, 0],
+      }),
+    );
+    // 두 번째 변경
+    history.execute(
+      "이동2",
+      new SetTransformCommand("a", {
+        position: [20, 0, 0],
+      }),
+    );
+
+    expect(history.stacks.undo).toEqual(
+      ["이동1", "이동2"],
+    );
+    history.undo(); // 이동2 취소
+    expect(history.stacks.redo).toEqual(
+      ["이동2"],
+    );
+
+    // 새 실행 → redo 비워야 함
+    history.execute(
+      "이동3",
+      new SetTransformCommand("a", {
+        position: [30, 0, 0],
+      }),
+    );
+    expect(history.stacks.undo).toEqual(
+      ["이동1", "이동3"],
+    );
+    expect(history.stacks.redo).toEqual(
+      [],
+    );
+    expect(
+      history.state.components
+        .transform["a"].position,
+    ).toEqual([30, 0, 0]);
+  });
+
+  it("빈 그룹(group 내 collect 미호출)은 기록되지 않는다", () => {
+    const history = new HistoryManager(
+      makeInitialState(),
+    );
+    history.group("빈 그룹", () => {
+      // collect 호출 없음
+    });
+    expect(history.stacks.undo).toEqual(
+      [],
+    );
+    expect(history.stacks.redo).toEqual(
+      [],
+    );
+  });
+});


### PR DESCRIPTION
- core 패키지에 트랜잭션 처리 로직 추가
  - 커맨드를 하나의 트랜잭션으로 합성할 수 있는 `CompositeCommand` 구현
  - 커맨드 컴포지션은 HistoryManager의 `group` 메서드에서 이루어짐
- 상태 변경 내역 기록 및 히스토리 기능 개선
  - `HistoryManager` 에서 상태 변경을 기록하고, undo/redo 기능 제공
  - 각 커맨드 실행 결과를 히스토리에 저장하여 이전 상태로 복원 가능
  - 관련 타입 정의 및 테스트 코드 작성/수정